### PR TITLE
BCW-67 [BE] 일정 생성 글자 수 제한 추가

### DIFF
--- a/be/src/main/java/com/ssb/scalendar/domain/schedule/dto/request/ScheduleCreateRequestDto.java
+++ b/be/src/main/java/com/ssb/scalendar/domain/schedule/dto/request/ScheduleCreateRequestDto.java
@@ -3,6 +3,7 @@ package com.ssb.scalendar.domain.schedule.dto.request;
 import com.ssb.scalendar.domain.schedule.entity.Schedule;
 import com.ssb.scalendar.domain.user.entity.User;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,6 +25,7 @@ public class ScheduleCreateRequestDto {
     private LocalTime scheduleTime;
 
     @NotNull(message = "내용은 필수 입력값입니다.")
+    @Size(max = 23, message = "일정은 23자 이하여야 합니다.")
     private String content;
 
     public Schedule toEntity(User user) {

--- a/be/src/main/java/com/ssb/scalendar/domain/schedule/entity/Schedule.java
+++ b/be/src/main/java/com/ssb/scalendar/domain/schedule/entity/Schedule.java
@@ -3,6 +3,7 @@ package com.ssb.scalendar.domain.schedule.entity;
 import com.ssb.scalendar.domain.user.entity.User;
 import com.ssb.scalendar.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,6 +27,8 @@ public class Schedule extends BaseTimeEntity {
     @Column(name = "schedule_time")
     private LocalTime scheduleTime;
 
+    @Column(length = 69)
+    @Size(max = 23)
     private String content;
 
     @ManyToOne

--- a/be/src/main/java/com/ssb/scalendar/global/exception/GlobalExceptionHandler.java
+++ b/be/src/main/java/com/ssb/scalendar/global/exception/GlobalExceptionHandler.java
@@ -5,12 +5,16 @@ import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -38,9 +42,19 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        List<String> errorMessages = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.toList());
+
+        String errorMessage = errorMessages.isEmpty()
+                ? "입력된 형식이 올바르지 않습니다."
+                : errorMessages.get(0);
+
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error("입력된 형식이 올바르지 않습니다.", "BAD_REQUEST"));
+                .body(ApiResponse.error(errorMessage, "BAD_REQUEST"));
     }
 
     @ExceptionHandler(IllegalArgumentException.class)


### PR DESCRIPTION
# .github/pull_request_template.md

## 🔍 관련 Jira 이슈

- BCW-67 [BE] 일정 생성 글자 수 제한 추가

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->
- 일정 생성 시 글자 수 제한(23자) 추가: DTO, Entity에서 모두 검증
- 예외 발생 시 API 응답으로 DTO에 작성한 검증 message가 반환되도록 수정



## ✅ PR 체크리스트

- [ ] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [ ] Jira 이슈 상태 업데이트

## 📌 참고 사항

