### PR TITLE
 BCW-71[FE] 할 일 입력 텍스트 길이 제한 설정 및 isComplete=fasle 설정

### DIFF
--- a/be/src/main/java/com/ssb/scalendar/domain/task/dto/request/TaskCreateRequestDto.java
+++ b/be/src/main/java/com/ssb/scalendar/domain/task/dto/request/TaskCreateRequestDto.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 
 import java.time.LocalDate;
 
@@ -15,11 +16,14 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TaskCreateRequestDto {
+    public static final int CONTENT_MIN_LENGTH = 1;
+    public static final int CONTENT_MAX_LENGTH = 23;
 
     @NotNull(message = "날짜는 필수 입력값입니다.")
     private LocalDate selectedDate;
 
     @NotNull(message = "내용은 필수 입력값입니다.")
+    @Length(min = CONTENT_MIN_LENGTH, max = CONTENT_MAX_LENGTH)
     private String content;
 
     public Task toEntity(User user) {

--- a/be/src/main/java/com/ssb/scalendar/domain/task/dto/request/TaskCreateRequestDto.java
+++ b/be/src/main/java/com/ssb/scalendar/domain/task/dto/request/TaskCreateRequestDto.java
@@ -23,7 +23,7 @@ public class TaskCreateRequestDto {
     private LocalDate selectedDate;
 
     @NotNull(message = "내용은 필수 입력값입니다.")
-    @Length(min = CONTENT_MIN_LENGTH, max = CONTENT_MAX_LENGTH)
+    @Length(min = CONTENT_MIN_LENGTH, max = CONTENT_MAX_LENGTH, message = "할 일은 23자 이하여야 합니다.")
     private String content;
 
     public Task toEntity(User user) {

--- a/be/src/main/java/com/ssb/scalendar/domain/task/entity/Task.java
+++ b/be/src/main/java/com/ssb/scalendar/domain/task/entity/Task.java
@@ -4,6 +4,7 @@ import com.ssb.scalendar.domain.task.dto.request.CheckTaskRequestDto;
 import com.ssb.scalendar.domain.user.entity.User;
 import com.ssb.scalendar.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +16,8 @@ import java.time.LocalDate;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Task extends BaseTimeEntity {
+    public static final int CONTENT_MAX_SIZE = 23;
+    public static final int CONTENT_MAX_LENGTH = CONTENT_MAX_SIZE * 3;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,9 +26,11 @@ public class Task extends BaseTimeEntity {
     @Column(name = "selected_date")
     private LocalDate selectedDate;
 
+    @Column(length = CONTENT_MAX_LENGTH)
+    @Size(max = CONTENT_MAX_SIZE)
     private String content;
 
-    private Boolean isCompleted;
+    private Boolean isCompleted = false;
 
     @ManyToOne
     @JoinColumn(name = "user_id")


### PR DESCRIPTION
# .github/pull_request_template.md

## 🔍 관련 Jira 이슈

- BCW-71[FE] 할 일 입력 텍스트 길이 제한 설정 및 isComplete=fasle 설정

## 📝 변경 사항

- 할 일 입력란의 텍스트 길이 제한 설정 추가 - 23자
- 할 일 입력사항의 길이 제한을 위해 entity와 dto의 content변수에 설정사항 추가 및 isComplete = fase 설정 



## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항

